### PR TITLE
chore: Bump Athens to chart version 0.4.11, for Athens version 0.8.1.

### DIFF
--- a/jx-app-athens/requirements.yaml
+++ b/jx-app-athens/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: "athens-proxy"
   repository: https://athens.blob.core.windows.net/charts
-  version: 0.2.11
+  version: 0.4.10


### PR DESCRIPTION
We need to bump past 0.6.1 minimum for Go 1.13 to work correctly with Athens, so we might as well go further.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>